### PR TITLE
Fix usage of nativescript-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "glob": "^5.0.15",
     "minimatch": "^3.0.0",
-    "nativescript-hook": "^0.1.1"
+    "nativescript-hook": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-babel",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,4 +1,5 @@
-require('nativescript-hook').postinstall(__dirname);
+var hook = require('nativescript-hook')(__dirname);
+hook.postinstall();
 
 var projectDir = process.env['TNS_PROJECT_DIR'];
 require('child_process').exec('npm install --save-dev babel-core', { cwd: projectDir }, function (err, stdout, stderr) {

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,1 +1,1 @@
-require('nativescript-hook').preuninstall(__dirname);
+require('nativescript-hook')(__dirname).preuninstall();


### PR DESCRIPTION
Use new version of nativescript-hook and fix the usage. Without the fix `tns install babel` is failing.

 Set version to 0.1.3
