### PR TITLE
When Babel fails to compile, report this to the calling CLI

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -28,19 +28,28 @@ module.exports = function (logger, platformsData, projectData, hookArgs) {
 		glob(path.join(outDir, 'app/**/*.js'), {}, function (err, files) {
 			if (err) {
 				reject(err);
-			} else {
-				files.forEach(function (jsFile) {
-					if (minimatch(jsFile, excludedPath)) {
-						return;
-					}
+				return;
+			}
 
-					logger.trace('Processing ' + jsFile);
+			var error = null;
+			files.forEach(function (jsFile) {
+				if (error || minimatch(jsFile, excludedPath)) {
+					return;
+				}
+
+				logger.trace('Processing ' + jsFile);
+				try {
 					var result = babel.transformFileSync(jsFile, babelOptions);
 					fs.writeFileSync(jsFile, result.code);
-				});
-				console.log('Processing complete');
-				resolve();
+				} catch(err) {
+					error = err;
+				}
+			});
+			console.log('Processing complete');
+			if (error) {
+				error.errorAsWarning = true;
 			}
+			error ? reject(error) : resolve();
 		});
 	});
 }


### PR DESCRIPTION
Do not let the CLI to crash

See https://github.com/NativeScript/nativescript-cli/issues/1337
