### PR TITLE
feat: provide support custom include and exclude patterns

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -5,6 +5,7 @@ var glob = require('glob');
 var minimatch = require('minimatch');
 
 module.exports = function (logger, platformsData, projectData, hookArgs) {
+	var logsPrefix = "nativescript-dev-babel: ";
 	var platformData = platformsData.getPlatformData(hookArgs.platform.toLowerCase());
 	var outDir = platformData.appDestinationDirectoryPath;
 
@@ -22,34 +23,43 @@ module.exports = function (logger, platformsData, projectData, hookArgs) {
 		}
 	}
 
-	return new Promise(function (resolve, reject) {
-		logger.trace('Looking for ' + path.join(outDir, '**/*.js'));
-		var excludedPath = path.join(outDir, 'app/tns_modules/**/*');
-		glob(path.join(outDir, 'app/**/*.js'), {}, function (err, files) {
-			if (err) {
-				reject(err);
-				return;
-			}
-
-			var error = null;
-			files.forEach(function (jsFile) {
-				if (error || minimatch(jsFile, excludedPath)) {
+	var includedPatterns = babelOptions.include || 'app/**/*.js';
+	includedPatterns = Array.isArray(includedPatterns) ? includedPatterns : [includedPatterns];
+	var excludedPatterns = babelOptions.exclude || path.join(outDir, 'app/tns_modules/**/*');
+	excludedPatterns = Array.isArray(excludedPatterns) ? excludedPatterns : [excludedPatterns];
+	var transformations = [];
+	for (var includePattern of includedPatterns) {
+		transformations.push(new Promise(function (resolve, reject) {
+			logger.info(`${logsPrefix}Processing '${path.join(outDir, includePattern)}.'`);
+			glob(path.join(outDir, includePattern), {}, function (err, files) {
+				if (err) {
+					reject(err);
 					return;
 				}
 
-				logger.trace('Processing ' + jsFile);
-				try {
-					var result = babel.transformFileSync(jsFile, babelOptions);
-					fs.writeFileSync(jsFile, result.code);
-				} catch(err) {
-					error = err;
+				var error = null;
+				files.forEach(function (jsFile) {
+					if (error || excludedPatterns.some(excludedPattern => minimatch(jsFile, excludedPattern))) {
+						return;
+					}
+
+					logger.trace(`${logsPrefix}Processing '${jsFile}'.`);
+					try {
+						var result = babel.transformFileSync(jsFile, babelOptions);
+						fs.writeFileSync(jsFile, result.code);
+					} catch (err) {
+						error = err;
+					}
+				});
+				logger.info(`${logsPrefix}Processing '${path.join(outDir, includePattern)}' complete.`);
+				if (error) {
+					error.errorAsWarning = true;
 				}
+				error ? reject(error) : resolve();
 			});
-			console.log('Processing complete');
-			if (error) {
-				error.errorAsWarning = true;
-			}
-			error ? reject(error) : resolve();
-		});
-	});
+		})
+		);
+	}
+
+	return Promise.all(transformations);
 }

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -1,4 +1,4 @@
-var babel = require('babel-core');
+var babel = require('@babel/core');
 var path = require('path');
 var fs = require('fs');
 var glob = require('glob');

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "nativescript-dev-babel",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "exit 0",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js"
   },
@@ -24,6 +23,7 @@
     "url": "https://github.com/NativeScript/nativescript-dev-babel.git"
   },
   "dependencies": {
+    "@babel/core": "^7.4.4",
     "glob": "^5.0.15",
     "minimatch": "^3.0.0",
     "nativescript-hook": "^0.2.0"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,11 +1,2 @@
 var hook = require('nativescript-hook')(__dirname);
 hook.postinstall();
-
-var projectDir = process.env['TNS_PROJECT_DIR'];
-require('child_process').exec('npm install --save-dev babel-core', { cwd: projectDir }, function (err, stdout, stderr) {
-	if (err) {
-		console.warn('npm: ' + err.toString());
-	}
-	process.stdout.write(stdout);
-	process.stderr.write(stderr);
-});


### PR DESCRIPTION
- Update to Babel 7 - Related to https://github.com/NativeScript/nativescript-dev-babel/pull/6
- Move Babel to dependency instead for manually installing it during post-install - Related to #5
- Support custom include and exclude patterns in order to allow post-processing of tns_modules